### PR TITLE
feat(devices): Add empty state for no active sessions

### DIFF
--- a/src/features/devices/ui/device-tab/DevicesTab.module.scss
+++ b/src/features/devices/ui/device-tab/DevicesTab.module.scss
@@ -15,3 +15,13 @@
 .button {
   align-self: flex-end;
 }
+
+.emptyText {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  margin-top: 84px;
+}

--- a/src/features/devices/ui/device-tab/DevicesTab.tsx
+++ b/src/features/devices/ui/device-tab/DevicesTab.tsx
@@ -38,7 +38,7 @@ export const DevicesTab = ({ data: { current, others }, ...rest }: DevicesTabPro
         </Typography>
         <DeviceItem data={current} isCurrent />
       </section>
-      {!!otherSessions.length && (
+      {otherSessions.length ? (
         <>
           <Button className={s.button} onClick={killAllSessionsHandler} variant={'outlined'}>
             {devicesTab.terminateAllOtherSessions}
@@ -52,6 +52,10 @@ export const DevicesTab = ({ data: { current, others }, ...rest }: DevicesTabPro
             ))}
           </section>
         </>
+      ) : (
+        <div className={s.emptyText}>
+          <Typography variant={'h1'}>{devicesTab.noActiveSessions}</Typography>
+        </div>
       )}
     </TabsContent>
   )

--- a/src/locales/en/profile-settings.ts
+++ b/src/locales/en/profile-settings.ts
@@ -4,6 +4,7 @@ export const profileSettings = {
     currentDevices: 'Current devices',
     lastVisit: 'Last visit',
     logout: 'Log out',
+    noActiveSessions: 'You have not yet logged in from other devices',
     terminateAllOtherSessions: 'Terminate all other session',
   },
   profileDataTab: {

--- a/src/locales/ru/profile-settings.ts
+++ b/src/locales/ru/profile-settings.ts
@@ -4,6 +4,7 @@ export const profileSettings = {
     currentDevices: 'Текущее устройство',
     lastVisit: 'Последний визит',
     logout: 'Выйти',
+    noActiveSessions: 'Вы еще не вошли в систему с других устройств',
     terminateAllOtherSessions: 'Завершить все другие сессии',
   },
   profileDataTab: {


### PR DESCRIPTION
<details>
<summary>Details</summary>

- Introduce a visual indicator for no active sessions in DevicesTab
- Add localization strings for English and Russian
- Center-align the message for better user clarity

</details>